### PR TITLE
replace ipl image with cv Mat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,48 +20,48 @@ EXEC=darknet
 OBJDIR=./obj/
 
 CC=gcc
-CPP=g++
-NVCC=nvcc 
+CPP=g++ -std=c++11
+NVCC=nvcc
 AR=ar
 ARFLAGS=rcs
 OPTS=-Ofast
-LDFLAGS= -lm -pthread 
+LDFLAGS= -lm -pthread
 COMMON= -Iinclude/ -Isrc/
 CFLAGS=-Wall -Wno-unused-result -Wno-unknown-pragmas -Wfatal-errors -fPIC
 
-ifeq ($(OPENMP), 1) 
+ifeq ($(OPENMP), 1)
 CFLAGS+= -fopenmp
 endif
 
-ifeq ($(DEBUG), 1) 
+ifeq ($(DEBUG), 1)
 OPTS=-O0 -g
 endif
 
 CFLAGS+=$(OPTS)
 
-ifeq ($(OPENCV), 1) 
+ifeq ($(OPENCV), 1)
 COMMON+= -DOPENCV
 CFLAGS+= -DOPENCV
-LDFLAGS+= `pkg-config --libs opencv` -lstdc++
-COMMON+= `pkg-config --cflags opencv` 
+LDFLAGS+= `pkg-config --libs opencv 2> /dev/null || pkg-config --libs opencv4` -lstdc++
+COMMON+= `pkg-config --cflags opencv 2> /dev/null || pkg-config --cflags opencv4`
 endif
 
-ifeq ($(GPU), 1) 
+ifeq ($(GPU), 1)
 COMMON+= -DGPU -I/usr/local/cuda/include/
 CFLAGS+= -DGPU
 LDFLAGS+= -L/usr/local/cuda/lib64 -lcuda -lcudart -lcublas -lcurand
 endif
 
-ifeq ($(CUDNN), 1) 
-COMMON+= -DCUDNN 
+ifeq ($(CUDNN), 1)
+COMMON+= -DCUDNN
 CFLAGS+= -DCUDNN
 LDFLAGS+= -lcudnn
 endif
 
 OBJ=gemm.o utils.o cuda.o deconvolutional_layer.o convolutional_layer.o list.o image.o activations.o im2col.o col2im.o blas.o crop_layer.o dropout_layer.o maxpool_layer.o softmax_layer.o data.o matrix.o network.o connected_layer.o cost_layer.o parser.o option_list.o detection_layer.o route_layer.o upsample_layer.o box.o normalization_layer.o avgpool_layer.o layer.o local_layer.o shortcut_layer.o logistic_layer.o activation_layer.o rnn_layer.o gru_layer.o crnn_layer.o demo.o batchnorm_layer.o region_layer.o reorg_layer.o tree.o  lstm_layer.o l2norm_layer.o yolo_layer.o iseg_layer.o image_opencv.o
 EXECOBJA=captcha.o lsd.o super.o art.o tag.o cifar.o go.o rnn.o segmenter.o regressor.o classifier.o coco.o yolo.o detector.o nightmare.o instance-segmenter.o darknet.o
-ifeq ($(GPU), 1) 
-LDFLAGS+= -lstdc++ 
+ifeq ($(GPU), 1)
+LDFLAGS+= -lstdc++
 OBJ+=convolutional_kernels.o deconvolutional_kernels.o activation_kernels.o im2col_kernels.o col2im_kernels.o blas_kernels.o crop_layer_kernels.o dropout_layer_kernels.o maxpool_layer_kernels.o avgpool_layer_kernels.o
 endif
 
@@ -102,4 +102,3 @@ results:
 
 clean:
 	rm -rf $(OBJS) $(SLIB) $(ALIB) $(EXEC) $(EXECOBJ) $(OBJDIR)/*
-

--- a/examples/attention.c
+++ b/examples/attention.c
@@ -455,5 +455,3 @@ void run_attention(int argc, char **argv)
     else if(0==strcmp(argv[2], "valid")) validate_attention_single(data, cfg, weights);
     else if(0==strcmp(argv[2], "validmulti")) validate_attention_multi(data, cfg, weights);
 }
-
-

--- a/src/image_opencv.cpp
+++ b/src/image_opencv.cpp
@@ -9,30 +9,34 @@ using namespace cv;
 
 extern "C" {
 
-IplImage *image_to_ipl(image im)
+Mat image_to_mat(image im)
 {
+    assert(im.c == 3 || im.c == 1);
     int x,y,c;
-    IplImage *disp = cvCreateImage(cvSize(im.w,im.h), IPL_DEPTH_8U, im.c);
-    int step = disp->widthStep;
+    image copy = copy_image(im);
+    constrain_image(copy);
+    if(im.c == 3) rgbgr_image(copy);
+    Mat m(im.h, im.w, CV_MAKETYPE(CV_8U, im.c));
     for(y = 0; y < im.h; ++y){
         for(x = 0; x < im.w; ++x){
             for(c= 0; c < im.c; ++c){
-                float val = im.data[c*im.h*im.w + y*im.w + x];
-                disp->imageData[y*step + x*im.c + c] = (unsigned char)(val*255);
+                float val = copy.data[c*im.h*im.w + y*im.w + x];
+                m.data[y*im.w*im.c + x*im.c + c] = (unsigned char)(val*255);
             }
         }
     }
-    return disp;
+    free_image(copy);
+    return m;
 }
 
-image ipl_to_image(IplImage* src)
+image mat_to_image(Mat m)
 {
-    int h = src->height;
-    int w = src->width;
-    int c = src->nChannels;
+    int h = m.rows;
+    int w = m.cols;
+    int c = m.channels();
     image im = make_image(w, h, c);
-    unsigned char *data = (unsigned char *)src->imageData;
-    int step = src->widthStep;
+    unsigned char *data = (unsigned char*)m.data;
+    int step = m.step;
     int i, j, k;
 
     for(i = 0; i < h; ++i){
@@ -42,26 +46,6 @@ image ipl_to_image(IplImage* src)
             }
         }
     }
-    return im;
-}
-
-Mat image_to_mat(image im)
-{
-    image copy = copy_image(im);
-    constrain_image(copy);
-    if(im.c == 3) rgbgr_image(copy);
-
-    IplImage *ipl = image_to_ipl(copy);
-    Mat m = cvarrToMat(ipl, true);
-    cvReleaseImage(&ipl);
-    free_image(copy);
-    return m;
-}
-
-image mat_to_image(Mat m)
-{
-    IplImage ipl = m;
-    image im = ipl_to_image(&ipl);
     rgbgr_image(im);
     return im;
 }
@@ -72,9 +56,9 @@ void *open_video_stream(const char *f, int c, int w, int h, int fps)
     if(f) cap = new VideoCapture(f);
     else cap = new VideoCapture(c);
     if(!cap->isOpened()) return 0;
-    if(w) cap->set(CV_CAP_PROP_FRAME_WIDTH, w);
-    if(h) cap->set(CV_CAP_PROP_FRAME_HEIGHT, w);
-    if(fps) cap->set(CV_CAP_PROP_FPS, w);
+    if(w) cap->set(CAP_PROP_FRAME_WIDTH, w);
+    if(h) cap->set(CAP_PROP_FRAME_HEIGHT, w);
+    if(fps) cap->set(CAP_PROP_FPS, w);
     return (void *) cap;
 }
 
@@ -121,9 +105,9 @@ int show_image_cv(image im, const char* name, int ms)
 
 void make_window(char *name, int w, int h, int fullscreen)
 {
-    namedWindow(name, WINDOW_NORMAL); 
+    namedWindow(name, WINDOW_NORMAL);
     if (fullscreen) {
-        setWindowProperty(name, CV_WND_PROP_FULLSCREEN, CV_WINDOW_FULLSCREEN);
+        setWindowProperty(name, WND_PROP_FULLSCREEN, WINDOW_FULLSCREEN);
     } else {
         resizeWindow(name, w, h);
         if(strcmp(name, "Demo") == 0) moveWindow(name, 0, 0);

--- a/src/image_opencv.cpp
+++ b/src/image_opencv.cpp
@@ -17,11 +17,13 @@ Mat image_to_mat(image im)
     constrain_image(copy);
     if(im.c == 3) rgbgr_image(copy);
     Mat m(im.h, im.w, CV_MAKETYPE(CV_8U, im.c));
+    int im_h_w = im.h*im.w;
+    int im_w_c = im.w*im.c;
     for(y = 0; y < im.h; ++y){
         for(x = 0; x < im.w; ++x){
             for(c= 0; c < im.c; ++c){
-                float val = copy.data[c*im.h*im.w + y*im.w + x];
-                m.data[y*im.w*im.c + x*im.c + c] = (unsigned char)(val*255);
+                float val = copy.data[c*im_h_w + y*im.w + x];
+                m.data[y*im_w_c + x*im.c + c] = (unsigned char)(val*255);
             }
         }
     }


### PR DESCRIPTION
PR removes deprecated `IplImage` and use `cv::Mat` instead. C Macros have been updated as well